### PR TITLE
Add new option snapshot_folder_path

### DIFF
--- a/cmd/frieza/cli.go
+++ b/cmd/frieza/cli.go
@@ -36,6 +36,7 @@ func cliRoot() cli.App {
 		WithCommand(cliClean()).
 		WithCommand(cliNuke()).
 		WithCommand(cliProvider()).
+		WithCommand(cliConfig()).
 		WithCommand(cliVersion())
 }
 

--- a/cmd/frieza/cli_clean.go
+++ b/cmd/frieza/cli_clean.go
@@ -32,7 +32,11 @@ func clean(customConfigPath string, snapshotName *string, plan bool, autoApprove
 		log.Fatalf("Cannot load configuration: %s", err.Error())
 	}
 
-	snapshot, err := SnapshotLoad(*snapshotName)
+	snapshotFolderPath, err := DefaultSnapshotFolderPath()
+	if err != nil {
+		log.Fatalf("Error while removing snapshot: %s", err.Error())
+	}
+	snapshot, err := SnapshotLoad(*snapshotName, snapshotFolderPath)
 	if err != nil {
 		log.Fatalf("Error load snapshot %s: %s", *snapshotName, err.Error())
 	}

--- a/cmd/frieza/cli_clean.go
+++ b/cmd/frieza/cli_clean.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	. "github.com/outscale-dev/frieza/internal/common"
+	"github.com/teris-io/cli"
+)
+
+func cliClean() cli.Command {
+	return cli.NewCommand("clean", "delete created resources since a specific snapshot").
+		WithOption(cli.NewOption("plan", "Only show what resource would be deleted").WithType(cli.TypeBool)).
+		WithOption(cli.NewOption("auto-approve", "Approve resource deletion without confirmation").WithType(cli.TypeBool)).
+		WithArg(cli.NewArg("snapshot_name", "snapshot")).
+		WithOption(cliConfigPath()).
+		WithOption(cliDebug()).
+		WithAction(func(args []string, options map[string]string) int {
+			setupDebug(options)
+			clean(options["config"], &args[0], options["plan"] == "true", options["auto-approve"] == "true")
+			return 0
+		})
+}
+
+func clean(customConfigPath string, snapshotName *string, plan bool, autoApprove bool) {
+	var configPath *string
+	if len(customConfigPath) > 0 {
+		configPath = &customConfigPath
+	}
+	config, err := ConfigLoad(configPath)
+	if err != nil {
+		log.Fatalf("Cannot load configuration: %s", err.Error())
+	}
+
+	snapshot, err := SnapshotLoad(*snapshotName)
+	if err != nil {
+		log.Fatalf("Error load snapshot %s: %s", *snapshotName, err.Error())
+	}
+
+	var providers []Provider
+	var objectsToDelete []Objects
+	objectsCount := 0
+
+	for _, data := range snapshot.Data {
+		profile, err := config.GetProfile(data.Profile)
+		if err != nil {
+			log.Fatalf("Error while getting profile %s: %s", data.Profile, err.Error())
+		}
+		provider, err := ProviderNew(*profile)
+		if err != nil {
+			log.Fatalf("Error intializing profile %s: %s", data.Profile, err.Error())
+		}
+		objects := ReadObjects(&provider)
+		diff := NewDiff()
+		diff.Build(&data.Objects, &objects)
+		count := ObjectsCount(&diff.Created)
+		objectsCount += count
+		if count > 0 {
+			fmt.Printf("Newly created object to delete in profile %s (%s):\n", profile.Name, provider.Name())
+			fmt.Printf(ObjectsPrint(&provider, &diff.Created))
+		} else {
+			fmt.Printf("No new object to delete in profile %s (%s)\n", profile.Name, provider.Name())
+		}
+		providers = append(providers, provider)
+		objectsToDelete = append(objectsToDelete, *&diff.Created)
+	}
+
+	if objectsCount == 0 {
+		fmt.Println("Nothing to delete, exiting")
+		return
+	}
+
+	if plan {
+		return
+	}
+
+	message := fmt.Sprintf("Do you really want to delete newly created resources?\n" +
+		"  Frieza will delete all resources shown above.")
+	if !confirmAction(&message, autoApprove) {
+		log.Fatal("Clean canceled")
+	}
+	loopDelete(providers, objectsToDelete)
+}

--- a/cmd/frieza/cli_clean.go
+++ b/cmd/frieza/cli_clean.go
@@ -31,12 +31,7 @@ func clean(customConfigPath string, snapshotName *string, plan bool, autoApprove
 	if err != nil {
 		log.Fatalf("Cannot load configuration: %s", err.Error())
 	}
-
-	snapshotFolderPath, err := DefaultSnapshotFolderPath()
-	if err != nil {
-		log.Fatalf("Error while removing snapshot: %s", err.Error())
-	}
-	snapshot, err := SnapshotLoad(*snapshotName, snapshotFolderPath)
+	snapshot, err := SnapshotLoad(*snapshotName, config.SnapshotFolderPath)
 	if err != nil {
 		log.Fatalf("Error load snapshot %s: %s", *snapshotName, err.Error())
 	}

--- a/cmd/frieza/cli_clean.go
+++ b/cmd/frieza/cli_clean.go
@@ -27,7 +27,7 @@ func clean(customConfigPath string, snapshotName *string, plan bool, autoApprove
 	if len(customConfigPath) > 0 {
 		configPath = &customConfigPath
 	}
-	config, err := ConfigLoad(configPath)
+	config, err := ConfigLoadWithDefault(configPath)
 	if err != nil {
 		log.Fatalf("Cannot load configuration: %s", err.Error())
 	}

--- a/cmd/frieza/cli_clean.go
+++ b/cmd/frieza/cli_clean.go
@@ -31,7 +31,7 @@ func clean(customConfigPath string, snapshotName *string, plan bool, autoApprove
 	if err != nil {
 		log.Fatalf("Cannot load configuration: %s", err.Error())
 	}
-	snapshot, err := SnapshotLoad(*snapshotName, config.SnapshotFolderPath)
+	snapshot, err := SnapshotLoad(*snapshotName, config)
 	if err != nil {
 		log.Fatalf("Error load snapshot %s: %s", *snapshotName, err.Error())
 	}

--- a/cmd/frieza/cli_config.go
+++ b/cmd/frieza/cli_config.go
@@ -10,7 +10,8 @@ import (
 
 func cliConfig() cli.Command {
 	return cli.NewCommand("config", "configure frieza options").
-		WithCommand(cliConfigLs())
+		WithCommand(cliConfigLs()).
+		WithCommand(cliConfigSet())
 }
 
 func cliConfigLs() cli.Command {
@@ -19,6 +20,17 @@ func cliConfigLs() cli.Command {
 		WithShortcut("ls").
 		WithAction(func(args []string, options map[string]string) int {
 			configLs(options["config"])
+			return 0
+		})
+}
+
+func cliConfigSet() cli.Command {
+	return cli.NewCommand("set", "set a specific option").
+		WithOption(cliConfigPath()).
+		WithArg(cli.NewArg("option_name", "option's name to set")).
+		WithArg(cli.NewArg("option_value", "option's value to set")).
+		WithAction(func(args []string, options map[string]string) int {
+			configSet(options["config"], &args[0], &args[1])
 			return 0
 		})
 }
@@ -32,11 +44,30 @@ func configLs(customConfigPath string) {
 	if err != nil {
 		log.Fatalf("Cannot load configuration: %s", err.Error())
 	}
-	fmt.Println("configuration path:", *configPath)
 	fmt.Println("version:", config.Version)
 	if len(config.SnapshotFolderPath) == 0 {
 		fmt.Println("snapshot_folder_path: (unset)")
 	} else {
 		fmt.Println("snapshot_folder_path:", config.SnapshotFolderPath)
+	}
+}
+
+func configSet(customConfigPath string, optionName *string, optionValue *string) {
+	var configPath *string
+	if len(customConfigPath) > 0 {
+		configPath = &customConfigPath
+	}
+	config, err := ConfigLoadWithDefault(configPath)
+	if err != nil {
+		log.Fatal("Cannot load configuration: " + err.Error())
+	}
+	switch *optionName {
+	case "snapshot_folder_path":
+		config.SnapshotFolderPath = *optionValue
+	default:
+		log.Fatalf("Unknow option name")
+	}
+	if err = config.Write(configPath); err != nil {
+		log.Fatalf("Cannot save configuration file: %s", err.Error())
 	}
 }

--- a/cmd/frieza/cli_config.go
+++ b/cmd/frieza/cli_config.go
@@ -10,9 +10,19 @@ import (
 
 func cliConfig() cli.Command {
 	return cli.NewCommand("config", "configure frieza options").
+		WithCommand(cliConfigDescribe()).
 		WithCommand(cliConfigLs()).
 		WithCommand(cliConfigSet()).
 		WithCommand(cliConfigRm())
+}
+
+func cliConfigDescribe() cli.Command {
+	return cli.NewCommand("describe", "describe all configuration options").
+		WithShortcut("desc").
+		WithAction(func(args []string, options map[string]string) int {
+			configDescribe()
+			return 0
+		})
 }
 
 func cliConfigLs() cli.Command {
@@ -45,6 +55,10 @@ func cliConfigRm() cli.Command {
 			configRm(options["config"], &args[0])
 			return 0
 		})
+}
+
+func configDescribe() {
+	fmt.Println("snapshot_folder_path: specify a folder path where snapshots are located")
 }
 
 func configLs(customConfigPath string) {

--- a/cmd/frieza/cli_config.go
+++ b/cmd/frieza/cli_config.go
@@ -11,7 +11,8 @@ import (
 func cliConfig() cli.Command {
 	return cli.NewCommand("config", "configure frieza options").
 		WithCommand(cliConfigLs()).
-		WithCommand(cliConfigSet())
+		WithCommand(cliConfigSet()).
+		WithCommand(cliConfigRm())
 }
 
 func cliConfigLs() cli.Command {
@@ -31,6 +32,17 @@ func cliConfigSet() cli.Command {
 		WithArg(cli.NewArg("option_value", "option's value to set")).
 		WithAction(func(args []string, options map[string]string) int {
 			configSet(options["config"], &args[0], &args[1])
+			return 0
+		})
+}
+
+func cliConfigRm() cli.Command {
+	return cli.NewCommand("remove", "delete a specific option (reset to default value)").
+		WithShortcut("rm").
+		WithOption(cliConfigPath()).
+		WithArg(cli.NewArg("option_name", "option's name to remove/unset")).
+		WithAction(func(args []string, options map[string]string) int {
+			configRm(options["config"], &args[0])
 			return 0
 		})
 }
@@ -64,6 +76,26 @@ func configSet(customConfigPath string, optionName *string, optionValue *string)
 	switch *optionName {
 	case "snapshot_folder_path":
 		config.SnapshotFolderPath = *optionValue
+	default:
+		log.Fatalf("Unknow option name")
+	}
+	if err = config.Write(configPath); err != nil {
+		log.Fatalf("Cannot save configuration file: %s", err.Error())
+	}
+}
+
+func configRm(customConfigPath string, optionName *string) {
+	var configPath *string
+	if len(customConfigPath) > 0 {
+		configPath = &customConfigPath
+	}
+	config, err := ConfigLoadWithDefault(configPath)
+	if err != nil {
+		log.Fatal("Cannot load configuration: " + err.Error())
+	}
+	switch *optionName {
+	case "snapshot_folder_path":
+		config.SnapshotFolderPath = ""
 	default:
 		log.Fatalf("Unknow option name")
 	}

--- a/cmd/frieza/cli_config.go
+++ b/cmd/frieza/cli_config.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	. "github.com/outscale-dev/frieza/internal/common"
+	"github.com/teris-io/cli"
+)
+
+func cliConfig() cli.Command {
+	return cli.NewCommand("config", "configure frieza options").
+		WithCommand(cliConfigLs())
+}
+
+func cliConfigLs() cli.Command {
+	return cli.NewCommand("list", "list configuration options").
+		WithOption(cliConfigPath()).
+		WithShortcut("ls").
+		WithAction(func(args []string, options map[string]string) int {
+			configLs(options["config"])
+			return 0
+		})
+}
+
+func configLs(customConfigPath string) {
+	var configPath *string
+	if len(customConfigPath) > 0 {
+		configPath = &customConfigPath
+	}
+	config, err := ConfigLoad(configPath)
+	if err != nil {
+		log.Fatalf("Cannot load configuration: %s", err.Error())
+	}
+	fmt.Println("configuration path:", *configPath)
+	fmt.Println("version:", config.Version)
+	if len(config.SnapshotFolderPath) == 0 {
+		fmt.Println("snapshot_folder_path: (unset)")
+	} else {
+		fmt.Println("snapshot_folder_path:", config.SnapshotFolderPath)
+	}
+}

--- a/cmd/frieza/cli_nuke.go
+++ b/cmd/frieza/cli_nuke.go
@@ -40,7 +40,7 @@ func nuke(customConfigPath string, profiles []string, plan bool, autoApprove boo
 		uniqueProfiles[profile] = true
 	}
 
-	config, err := ConfigLoad(configPath)
+	config, err := ConfigLoadWithDefault(configPath)
 	if err != nil {
 		log.Fatalf("Cannot load configuration: %s", err.Error())
 	}

--- a/cmd/frieza/cli_nuke.go
+++ b/cmd/frieza/cli_nuke.go
@@ -11,20 +11,6 @@ import (
 	"github.com/teris-io/cli"
 )
 
-func cliClean() cli.Command {
-	return cli.NewCommand("clean", "delete created resources since a specific snapshot").
-		WithOption(cli.NewOption("plan", "Only show what resource would be deleted").WithType(cli.TypeBool)).
-		WithOption(cli.NewOption("auto-approve", "Approve resource deletion without confirmation").WithType(cli.TypeBool)).
-		WithArg(cli.NewArg("snapshot_name", "snapshot")).
-		WithOption(cliConfigPath()).
-		WithOption(cliDebug()).
-		WithAction(func(args []string, options map[string]string) int {
-			setupDebug(options)
-			clean(options["config"], &args[0], options["plan"] == "true", options["auto-approve"] == "true")
-			return 0
-		})
-}
-
 func cliNuke() cli.Command {
 	return cli.NewCommand("nuke", "delete ALL resources of specified profiles").
 		WithOption(cli.NewOption("plan", "Only show what resource would be deleted").WithType(cli.TypeBool)).
@@ -37,66 +23,6 @@ func cliNuke() cli.Command {
 			nuke(options["config"], args, options["plan"] == "true", options["auto-approve"] == "true")
 			return 0
 		})
-}
-
-func clean(customConfigPath string, snapshotName *string, plan bool, autoApprove bool) {
-	var configPath *string
-	if len(customConfigPath) > 0 {
-		configPath = &customConfigPath
-	}
-	config, err := ConfigLoad(configPath)
-	if err != nil {
-		log.Fatalf("Cannot load configuration: %s", err.Error())
-	}
-
-	snapshot, err := SnapshotLoad(*snapshotName)
-	if err != nil {
-		log.Fatalf("Error load snapshot %s: %s", *snapshotName, err.Error())
-	}
-
-	var providers []Provider
-	var objectsToDelete []Objects
-	objectsCount := 0
-
-	for _, data := range snapshot.Data {
-		profile, err := config.GetProfile(data.Profile)
-		if err != nil {
-			log.Fatalf("Error while getting profile %s: %s", data.Profile, err.Error())
-		}
-		provider, err := ProviderNew(*profile)
-		if err != nil {
-			log.Fatalf("Error intializing profile %s: %s", data.Profile, err.Error())
-		}
-		objects := ReadObjects(&provider)
-		diff := NewDiff()
-		diff.Build(&data.Objects, &objects)
-		count := ObjectsCount(&diff.Created)
-		objectsCount += count
-		if count > 0 {
-			fmt.Printf("Newly created object to delete in profile %s (%s):\n", profile.Name, provider.Name())
-			fmt.Printf(ObjectsPrint(&provider, &diff.Created))
-		} else {
-			fmt.Printf("No new object to delete in profile %s (%s)\n", profile.Name, provider.Name())
-		}
-		providers = append(providers, provider)
-		objectsToDelete = append(objectsToDelete, *&diff.Created)
-	}
-
-	if objectsCount == 0 {
-		fmt.Println("Nothing to delete, exiting")
-		return
-	}
-
-	if plan {
-		return
-	}
-
-	message := fmt.Sprintf("Do you really want to delete newly created resources?\n" +
-		"  Frieza will delete all resources shown above.")
-	if !confirmAction(&message, autoApprove) {
-		log.Fatal("Clean canceled")
-	}
-	loopDelete(providers, objectsToDelete)
 }
 
 func nuke(customConfigPath string, profiles []string, plan bool, autoApprove bool) {

--- a/cmd/frieza/cli_profile.go
+++ b/cmd/frieza/cli_profile.go
@@ -94,7 +94,7 @@ func profileLs(customConfigPath string) {
 	if len(customConfigPath) > 0 {
 		configPath = &customConfigPath
 	}
-	config, err := ConfigLoad(configPath)
+	config, err := ConfigLoadWithDefault(configPath)
 	if err != nil {
 		log.Fatalf("Cannot load configuration: %s", err.Error())
 	}
@@ -108,7 +108,7 @@ func profileDescribe(customConfigPath string, profileName *string) {
 	if len(customConfigPath) > 0 {
 		configPath = &customConfigPath
 	}
-	config, err := ConfigLoad(configPath)
+	config, err := ConfigLoadWithDefault(configPath)
 	if err != nil {
 		log.Fatalf("Cannot load configuration: %s", err.Error())
 	}
@@ -127,7 +127,7 @@ func profileNew(customConfigPath string, newProfile Profile) {
 	if len(customConfigPath) > 0 {
 		configPath = &customConfigPath
 	}
-	config, err := ConfigLoad(configPath)
+	config, err := ConfigLoadWithDefault(configPath)
 	if err != nil {
 		config = ConfigNew()
 		if GlobalCliOptions.debug {
@@ -152,7 +152,7 @@ func profileRm(customConfigPath string, profileName *string) {
 	if len(customConfigPath) > 0 {
 		configPath = &customConfigPath
 	}
-	config, err := ConfigLoad(configPath)
+	config, err := ConfigLoadWithDefault(configPath)
 	if err != nil {
 		log.Fatal("Cannot load configuration: " + err.Error())
 	}
@@ -172,7 +172,7 @@ func profileTest(customConfigPath string, profileName *string) {
 	if len(customConfigPath) > 0 {
 		configPath = &customConfigPath
 	}
-	config, err := ConfigLoad(configPath)
+	config, err := ConfigLoadWithDefault(configPath)
 	if err != nil {
 		log.Fatalf("Cannot load configuration: %s", err.Error())
 	}

--- a/cmd/frieza/cli_snapshot.go
+++ b/cmd/frieza/cli_snapshot.go
@@ -85,12 +85,7 @@ func snapshotNew(customConfigPath string, args []string) {
 	if err != nil {
 		log.Fatalf("Cannot load configuration: %s", err.Error())
 	}
-
-	snapshotFolderPath, err := DefaultSnapshotFolderPath()
-	if err != nil {
-		log.Fatalf("Cannot get default snapshot folder: %s", err.Error())
-	}
-	if _, err = SnapshotLoad(snapshotName, snapshotFolderPath); err == nil {
+	if _, err = SnapshotLoad(snapshotName, config.SnapshotFolderPath); err == nil {
 		log.Fatalf("Snapshot %s already exist", snapshotName)
 	}
 
@@ -138,12 +133,16 @@ func snapshotNew(customConfigPath string, args []string) {
 	}
 }
 
-func snapshotLs(configPath string) {
-	snapshotFolderPath, err := DefaultSnapshotFolderPath()
-	if err != nil {
-		log.Fatalf("Error while listing snapshots: %s", err.Error())
+func snapshotLs(customConfigPath string) {
+	var configPath *string
+	if len(customConfigPath) > 0 {
+		configPath = &customConfigPath
 	}
-	files, err := ioutil.ReadDir(snapshotFolderPath)
+	config, err := ConfigLoad(configPath)
+	if err != nil {
+		log.Fatalf("Cannot load configuration: %s", err.Error())
+	}
+	files, err := ioutil.ReadDir(config.SnapshotFolderPath)
 	if err != nil {
 		log.Fatalf("Error while listing snapshots: %s", err.Error())
 	}
@@ -152,30 +151,41 @@ func snapshotLs(configPath string) {
 			continue
 		}
 		snapshotName := strings.TrimSuffix(file.Name(), ".json")
-		if snapshot, err := SnapshotLoad(snapshotName, snapshotFolderPath); err == nil {
+		if snapshot, err := SnapshotLoad(snapshotName, config.SnapshotFolderPath); err == nil {
 			fmt.Println(snapshot.Name)
 		}
 	}
 }
 
-func snapshotDescribe(configPath string, snapshotName *string) {
-	snapshotFolderPath, err := DefaultSnapshotFolderPath()
+func snapshotDescribe(customConfigPath string, snapshotName *string) {
+	var configPath *string
+	if len(customConfigPath) > 0 {
+		configPath = &customConfigPath
+	}
+	config, err := ConfigLoad(configPath)
+	if err != nil {
+		log.Fatalf("Cannot load configuration: %s", err.Error())
+	}
 	if err != nil {
 		log.Fatalf("Error while reading snapshots: %s", err.Error())
 	}
-	snapshot, err := SnapshotLoad(*snapshotName, snapshotFolderPath)
+	snapshot, err := SnapshotLoad(*snapshotName, config.SnapshotFolderPath)
 	if err != nil {
 		log.Fatalf("Cannot load snapshot %s: %s", *snapshotName, err.Error())
 	}
 	fmt.Print(snapshot)
 }
 
-func snapshotRm(configPath string, snapshotName *string) {
-	snapshotFolderPath, err := DefaultSnapshotFolderPath()
-	if err != nil {
-		log.Fatalf("Error while removing snapshot: %s", err.Error())
+func snapshotRm(customConfigPath string, snapshotName *string) {
+	var configPath *string
+	if len(customConfigPath) > 0 {
+		configPath = &customConfigPath
 	}
-	snapshot, err := SnapshotLoad(*snapshotName, snapshotFolderPath)
+	config, err := ConfigLoad(configPath)
+	if err != nil {
+		log.Fatalf("Cannot load configuration: %s", err.Error())
+	}
+	snapshot, err := SnapshotLoad(*snapshotName, config.SnapshotFolderPath)
 	if err != nil {
 		log.Fatalf("Error while deleting snapshot %s: %s", *snapshotName, err.Error())
 	}

--- a/cmd/frieza/cli_snapshot.go
+++ b/cmd/frieza/cli_snapshot.go
@@ -85,7 +85,7 @@ func snapshotNew(customConfigPath string, args []string) {
 	if err != nil {
 		log.Fatalf("Cannot load configuration: %s", err.Error())
 	}
-	if _, err = SnapshotLoad(snapshotName, config.SnapshotFolderPath); err == nil {
+	if _, err = SnapshotLoad(snapshotName, config); err == nil {
 		log.Fatalf("Snapshot %s already exist", snapshotName)
 	}
 
@@ -121,6 +121,7 @@ func snapshotNew(customConfigPath string, args []string) {
 		Version: SnapshotVersion(),
 		Name:    snapshotName,
 		Date:    date,
+		Config:  config,
 	}
 	for i, provider := range providers {
 		snapshot.Data = append(snapshot.Data, SnapshotData{
@@ -151,7 +152,7 @@ func snapshotLs(customConfigPath string) {
 			continue
 		}
 		snapshotName := strings.TrimSuffix(file.Name(), ".json")
-		if snapshot, err := SnapshotLoad(snapshotName, config.SnapshotFolderPath); err == nil {
+		if snapshot, err := SnapshotLoad(snapshotName, config); err == nil {
 			fmt.Println(snapshot.Name)
 		}
 	}
@@ -169,7 +170,7 @@ func snapshotDescribe(customConfigPath string, snapshotName *string) {
 	if err != nil {
 		log.Fatalf("Error while reading snapshots: %s", err.Error())
 	}
-	snapshot, err := SnapshotLoad(*snapshotName, config.SnapshotFolderPath)
+	snapshot, err := SnapshotLoad(*snapshotName, config)
 	if err != nil {
 		log.Fatalf("Cannot load snapshot %s: %s", *snapshotName, err.Error())
 	}
@@ -185,7 +186,7 @@ func snapshotRm(customConfigPath string, snapshotName *string) {
 	if err != nil {
 		log.Fatalf("Cannot load configuration: %s", err.Error())
 	}
-	snapshot, err := SnapshotLoad(*snapshotName, config.SnapshotFolderPath)
+	snapshot, err := SnapshotLoad(*snapshotName, config)
 	if err != nil {
 		log.Fatalf("Error while deleting snapshot %s: %s", *snapshotName, err.Error())
 	}

--- a/cmd/frieza/cli_snapshot.go
+++ b/cmd/frieza/cli_snapshot.go
@@ -86,7 +86,11 @@ func snapshotNew(customConfigPath string, args []string) {
 		log.Fatalf("Cannot load configuration: %s", err.Error())
 	}
 
-	if _, err = SnapshotLoad(snapshotName); err == nil {
+	snapshotFolderPath, err := DefaultSnapshotFolderPath()
+	if err != nil {
+		log.Fatalf("Cannot get default snapshot folder: %s", err.Error())
+	}
+	if _, err = SnapshotLoad(snapshotName, snapshotFolderPath); err == nil {
 		log.Fatalf("Snapshot %s already exist", snapshotName)
 	}
 
@@ -135,11 +139,11 @@ func snapshotNew(customConfigPath string, args []string) {
 }
 
 func snapshotLs(configPath string) {
-	snapshotPath, err := DefaultSnapshotFolderPath()
+	snapshotFolderPath, err := DefaultSnapshotFolderPath()
 	if err != nil {
 		log.Fatalf("Error while listing snapshots: %s", err.Error())
 	}
-	files, err := ioutil.ReadDir(snapshotPath)
+	files, err := ioutil.ReadDir(snapshotFolderPath)
 	if err != nil {
 		log.Fatalf("Error while listing snapshots: %s", err.Error())
 	}
@@ -148,14 +152,18 @@ func snapshotLs(configPath string) {
 			continue
 		}
 		snapshotName := strings.TrimSuffix(file.Name(), ".json")
-		if snapshot, err := SnapshotLoad(snapshotName); err == nil {
+		if snapshot, err := SnapshotLoad(snapshotName, snapshotFolderPath); err == nil {
 			fmt.Println(snapshot.Name)
 		}
 	}
 }
 
 func snapshotDescribe(configPath string, snapshotName *string) {
-	snapshot, err := SnapshotLoad(*snapshotName)
+	snapshotFolderPath, err := DefaultSnapshotFolderPath()
+	if err != nil {
+		log.Fatalf("Error while reading snapshots: %s", err.Error())
+	}
+	snapshot, err := SnapshotLoad(*snapshotName, snapshotFolderPath)
 	if err != nil {
 		log.Fatalf("Cannot load snapshot %s: %s", *snapshotName, err.Error())
 	}
@@ -163,7 +171,11 @@ func snapshotDescribe(configPath string, snapshotName *string) {
 }
 
 func snapshotRm(configPath string, snapshotName *string) {
-	snapshot, err := SnapshotLoad(*snapshotName)
+	snapshotFolderPath, err := DefaultSnapshotFolderPath()
+	if err != nil {
+		log.Fatalf("Error while removing snapshot: %s", err.Error())
+	}
+	snapshot, err := SnapshotLoad(*snapshotName, snapshotFolderPath)
 	if err != nil {
 		log.Fatalf("Error while deleting snapshot %s: %s", *snapshotName, err.Error())
 	}

--- a/cmd/frieza/cli_snapshot.go
+++ b/cmd/frieza/cli_snapshot.go
@@ -81,7 +81,7 @@ func snapshotNew(customConfigPath string, args []string) {
 	if len(customConfigPath) > 0 {
 		configPath = &customConfigPath
 	}
-	config, err := ConfigLoad(configPath)
+	config, err := ConfigLoadWithDefault(configPath)
 	if err != nil {
 		log.Fatalf("Cannot load configuration: %s", err.Error())
 	}
@@ -138,7 +138,7 @@ func snapshotLs(customConfigPath string) {
 	if len(customConfigPath) > 0 {
 		configPath = &customConfigPath
 	}
-	config, err := ConfigLoad(configPath)
+	config, err := ConfigLoadWithDefault(configPath)
 	if err != nil {
 		log.Fatalf("Cannot load configuration: %s", err.Error())
 	}
@@ -162,7 +162,7 @@ func snapshotDescribe(customConfigPath string, snapshotName *string) {
 	if len(customConfigPath) > 0 {
 		configPath = &customConfigPath
 	}
-	config, err := ConfigLoad(configPath)
+	config, err := ConfigLoadWithDefault(configPath)
 	if err != nil {
 		log.Fatalf("Cannot load configuration: %s", err.Error())
 	}
@@ -181,7 +181,7 @@ func snapshotRm(customConfigPath string, snapshotName *string) {
 	if len(customConfigPath) > 0 {
 		configPath = &customConfigPath
 	}
-	config, err := ConfigLoad(configPath)
+	config, err := ConfigLoadWithDefault(configPath)
 	if err != nil {
 		log.Fatalf("Cannot load configuration: %s", err.Error())
 	}

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,6 +80,11 @@ Note that a listing of deleted resources is show before any action.
 
 Confirmation is asked by default but you can overide this behavior with `--auto-approve` option.
 
+## Set configuration
+
+Frieza has a number of options which can set or unset.
+Feel free to explore `frieza config` sub-commands.
+
 # License
 
 > Copyright Outscale SAS

--- a/internal/common/config.go
+++ b/internal/common/config.go
@@ -27,14 +27,16 @@ func ConfigVersion() int {
 }
 
 type Config struct {
-	Version  int       `json:"version"`
-	Profiles []Profile `json:"profiles"`
+	Version            int       `json:"version"`
+	Profiles           []Profile `json:"profiles"`
+	SnapshotFolderPath string    `json:"snapshot_folder_path,omitempty"`
 }
 
 func ConfigNew() *Config {
 	return &Config{
-		Version:  ConfigVersion(),
-		Profiles: []Profile{},
+		Version:            ConfigVersion(),
+		Profiles:           []Profile{},
+		SnapshotFolderPath: "",
 	}
 }
 
@@ -52,6 +54,14 @@ func DefaultConfigPath() (string, error) {
 		return "", err
 	}
 	return path.Join(folderPath, "config.json"), nil
+}
+
+func DefaultSnapshotFolderPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return path.Join(home, ".frieza", "snapshots"), nil
 }
 
 func ConfigLoad(customConfigPath *string) (*Config, error) {
@@ -75,6 +85,12 @@ func ConfigLoad(customConfigPath *string) (*Config, error) {
 	}
 	if config.Version > ConfigVersion() {
 		return nil, errors.New("configuration version not supported, please upgrade frieza")
+	}
+	if len(config.SnapshotFolderPath) == 0 {
+		config.SnapshotFolderPath, err = DefaultSnapshotFolderPath()
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &config, nil
 }

--- a/internal/common/config.go
+++ b/internal/common/config.go
@@ -64,6 +64,20 @@ func DefaultSnapshotFolderPath() (string, error) {
 	return path.Join(home, ".frieza", "snapshots"), nil
 }
 
+func ConfigLoadWithDefault(customConfigPath *string) (*Config, error) {
+	config, err := ConfigLoad(customConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(config.SnapshotFolderPath) == 0 {
+		config.SnapshotFolderPath, err = DefaultSnapshotFolderPath()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return config, nil
+}
+
 func ConfigLoad(customConfigPath *string) (*Config, error) {
 	var configPath string
 	var err error
@@ -85,12 +99,6 @@ func ConfigLoad(customConfigPath *string) (*Config, error) {
 	}
 	if config.Version > ConfigVersion() {
 		return nil, errors.New("configuration version not supported, please upgrade frieza")
-	}
-	if len(config.SnapshotFolderPath) == 0 {
-		config.SnapshotFolderPath, err = DefaultSnapshotFolderPath()
-		if err != nil {
-			return nil, err
-		}
 	}
 	return &config, nil
 }

--- a/internal/common/snapshot.go
+++ b/internal/common/snapshot.go
@@ -12,11 +12,11 @@ import (
 type Objects = map[ObjectType][]Object
 
 type Snapshot struct {
-	Version    int            `json:"version"`
-	Name       string         `json:"name"`
-	Date       string         `json:"date"`
-	Data       []SnapshotData `json:"data"`
-	FolderPath string         `json:"-"`
+	Version int            `json:"version"`
+	Name    string         `json:"name"`
+	Date    string         `json:"date"`
+	Data    []SnapshotData `json:"data"`
+	Config  *Config        `json:"-"`
 }
 
 type SnapshotData struct {
@@ -130,7 +130,7 @@ func ObjectsPrint(provider *Provider, objects *Objects) string {
 }
 
 func (snapshot *Snapshot) Write() error {
-	if err := os.MkdirAll(snapshot.FolderPath, os.ModePerm); err != nil {
+	if err := os.MkdirAll(snapshot.Config.SnapshotFolderPath, os.ModePerm); err != nil {
 		return err
 	}
 	json_bytes, err := json.MarshalIndent(snapshot, "", "  ")
@@ -144,13 +144,13 @@ func (snapshot *Snapshot) Write() error {
 }
 
 func (snapshot *Snapshot) Path() string {
-	return path.Join(snapshot.FolderPath, snapshot.Name+".json")
+	return path.Join(snapshot.Config.SnapshotFolderPath, snapshot.Name+".json")
 }
 
-func SnapshotLoad(name string, snapshotFolderPath string) (*Snapshot, error) {
+func SnapshotLoad(name string, config *Config) (*Snapshot, error) {
 	snapshot := &Snapshot{
-		Name:       name,
-		FolderPath: snapshotFolderPath,
+		Name:   name,
+		Config: config,
 	}
 	snapshot_json, err := ioutil.ReadFile(snapshot.Path())
 	if err != nil {

--- a/internal/common/snapshot.go
+++ b/internal/common/snapshot.go
@@ -129,14 +129,6 @@ func ObjectsPrint(provider *Provider, objects *Objects) string {
 	return out
 }
 
-func DefaultSnapshotFolderPath() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return path.Join(home, ".frieza", "snapshots"), nil
-}
-
 func (snapshot *Snapshot) Write() error {
 	if err := os.MkdirAll(snapshot.FolderPath, os.ModePerm); err != nil {
 		return err


### PR DESCRIPTION
This pr allow users to specify their snapshot folder.

As this is the first option which can be stored in config.json and is not part of snapshot sub-commands, this PR introduce a new sub-command "config" which helps managing options and their values.