### PR TITLE
🐛 fix: abort snapshot on throttling errors

### DIFF
--- a/cmd/frieza/cli_clean.go
+++ b/cmd/frieza/cli_clean.go
@@ -80,7 +80,10 @@ func clean(customConfigPath string, snapshotName *string, plan bool, autoApprove
 		if err != nil {
 			cliFatalf(jsonOutput, "Error intializing profile %s: %s", data.Profile, err.Error())
 		}
-		objects := ReadObjects(&provider)
+		objects, err := ReadObjects(&provider)
+		if err != nil {
+			log.Fatalf("Error reading objects: %v", err)
+		}
 		if resourcesFilter != nil {
 			objects = FiltersObjects(&objects, resourcesFilter)
 		}

--- a/cmd/frieza/cli_nuke.go
+++ b/cmd/frieza/cli_nuke.go
@@ -83,7 +83,10 @@ func nuke(customConfigPath string, profiles []string, plan bool, autoApprove boo
 		if err != nil {
 			cliFatalf(jsonOutput, "Error intializing profile %s: %s", profileName, err.Error())
 		}
-		objectsToDelete := ReadObjects(&provider)
+		objectsToDelete, err := ReadObjects(&provider)
+		if err != nil {
+			log.Fatalf("Error reading objects: %v", err)
+		}
 		if resourceFilter != nil {
 			objectsToDelete = FiltersObjects(&objectsToDelete, resourceFilter)
 		}

--- a/cmd/frieza/cli_snapshot.go
+++ b/cmd/frieza/cli_snapshot.go
@@ -139,9 +139,13 @@ func snapshotNew(customConfigPath string, args []string) {
 		Config:  config,
 	}
 	for i, provider := range providers {
+		objs, err := ReadObjects(&provider)
+		if err != nil {
+			log.Fatalf("Error reading objects: %v\n", err)
+		}
 		snapshot.Data = append(snapshot.Data, SnapshotData{
 			Profile: profiles[i],
-			Objects: ReadObjects(&provider),
+			Objects: objs,
 		})
 	}
 	if err = snapshot.Write(); err != nil {
@@ -238,7 +242,10 @@ func snapshotUpdate(customConfigPath string, snapshotName *string, incrementalUp
 			log.Fatalf("Provider test failed for profile %s: %s", profile.Name, err.Error())
 		}
 
-		objects := ReadObjects(&provider)
+		objects, err := ReadObjects(&provider)
+		if err != nil {
+			log.Fatalf("Error reading objects: %v\n", err)
+		}
 		diff := NewDiff()
 		diff.Build(&data.Objects, &objects)
 		for key, value := range diff.Created {

--- a/cmd/frieza/destroyer.go
+++ b/cmd/frieza/destroyer.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -120,7 +121,10 @@ func (destroyer *Destroyer) run() {
 		}
 		for i, target := range destroyer.Targets {
 			diff := NewDiff()
-			remaining := ReadNonEmptyObjects(target.provider, *objects[i])
+			remaining, err := ReadNonEmptyObjects(target.provider, *objects[i])
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error reading: %v\n", err)
+			}
 			diff.Build(&remaining, objects[i])
 			objects[i] = &diff.Retained
 		}

--- a/internal/common/provider.go
+++ b/internal/common/provider.go
@@ -9,7 +9,7 @@ type Provider interface {
 	Name() string
 	Types() []ObjectType
 	AuthTest() error
-	ReadObjects(typeName string) []Object
+	ReadObjects(typeName string) ([]Object, error)
 	DeleteObjects(typeName string, objects []Object)
 	StringObject(object string, typeName string) string
 }

--- a/internal/common/snapshot.go
+++ b/internal/common/snapshot.go
@@ -33,12 +33,16 @@ func SnapshotVersion() int {
 	return 0
 }
 
-func ReadObjects(provider *Provider) Objects {
+func ReadObjects(provider *Provider) (Objects, error) {
 	objects := make(Objects)
 	for _, typeName := range (*provider).Types() {
-		objects[typeName] = (*provider).ReadObjects(typeName)
+		var err error
+		objects[typeName], err = (*provider).ReadObjects(typeName)
+		if err != nil {
+			return objects, err
+		}
 	}
-	return objects
+	return objects, nil
 }
 
 func FiltersObjects(objects *Objects, resourceFilter ResourceFilter) Objects {
@@ -51,15 +55,19 @@ func FiltersObjects(objects *Objects, resourceFilter ResourceFilter) Objects {
 	return filteredObjects
 }
 
-func ReadNonEmptyObjects(provider *Provider, nonEmpy Objects) Objects {
+func ReadNonEmptyObjects(provider *Provider, nonEmpy Objects) (Objects, error) {
 	objects := make(Objects)
 	for _, typeName := range (*provider).Types() {
 		if len(nonEmpy[typeName]) == 0 {
 			continue
 		}
-		objects[typeName] = (*provider).ReadObjects(typeName)
+		var err error
+		objects[typeName], err = (*provider).ReadObjects(typeName)
+		if err != nil {
+			return objects, err
+		}
 	}
-	return objects
+	return objects, nil
 }
 
 func DeleteObjects(provider *Provider, objects Objects) {

--- a/internal/providers/fs/fs.go
+++ b/internal/providers/fs/fs.go
@@ -62,14 +62,14 @@ func (provider *FileSystem) AuthTest() error {
 	return nil
 }
 
-func (provider *FileSystem) ReadObjects(typeName string) []Object {
+func (provider *FileSystem) ReadObjects(typeName string) ([]Object, error) {
 	switch typeName {
 	case typeFile:
 		return provider.readFiles()
 	case typeFolder:
 		return provider.readFolders()
 	}
-	return []Object{}
+	return []Object{}, nil
 }
 
 func (provider *FileSystem) DeleteObjects(typeName string, objects []Object) {
@@ -85,12 +85,11 @@ func (provider *FileSystem) StringObject(object string, typeName string) string 
 	return object
 }
 
-func (provider *FileSystem) readFiles() []Object {
+func (provider *FileSystem) readFiles() ([]Object, error) {
 	files := make([]Object, 0)
 
 	if err := os.Chdir(provider.Path); err != nil {
-		log.Printf("cannot move to directory: %s", err.Error())
-		return files
+		return nil, fmt.Errorf("chdir: %w", err)
 	}
 
 	folderStack := []string{"."}
@@ -99,8 +98,7 @@ func (provider *FileSystem) readFiles() []Object {
 		folderStack = folderStack[:len(folderStack)-1]
 		dir, err := os.ReadDir(dirPath)
 		if err != nil {
-			log.Printf("cannot read directory: %s", err.Error())
-			continue
+			return nil, fmt.Errorf("read dir: %w", err)
 		}
 		for _, node := range dir {
 			nodePath := path.Join(dirPath, node.Name())
@@ -112,7 +110,7 @@ func (provider *FileSystem) readFiles() []Object {
 			}
 		}
 	}
-	return files
+	return files, nil
 }
 
 func (provider *FileSystem) deleteFiles(files []Object) {
@@ -127,12 +125,11 @@ func (provider *FileSystem) deleteFiles(files []Object) {
 	}
 }
 
-func (provider *FileSystem) readFolders() []Object {
+func (provider *FileSystem) readFolders() ([]Object, error) {
 	folders := make([]Object, 0)
 
 	if err := os.Chdir(provider.Path); err != nil {
-		log.Printf("cannot move to directory: %s", err.Error())
-		return folders
+		return nil, fmt.Errorf("chdir: %w", err)
 	}
 
 	folderStack := []string{"."}
@@ -152,7 +149,7 @@ func (provider *FileSystem) readFolders() []Object {
 			}
 		}
 	}
-	return folders
+	return folders, nil
 }
 
 func (provider *FileSystem) deleteFolders(folders []Object) {

--- a/internal/providers/outscale_oapi/utils.go
+++ b/internal/providers/outscale_oapi/utils.go
@@ -19,13 +19,13 @@ func extractApiError(err error) (bool, *osc.ErrorResponse) {
 	return false, nil
 }
 
-func getErrorInfo(err error, httpRes *http.Response) string {
+func getErrorInfo(err error, httpRes *http.Response) error {
 	if ok, apiError := extractApiError(err); ok {
-		return fmt.Sprintf("%v %v %v %v", httpRes.Status, apiError.GetErrors()[0].GetCode(), apiError.GetErrors()[0].GetType(), apiError.GetErrors()[0].GetDetails())
+		return fmt.Errorf("%v %v %v %v", httpRes.Status, apiError.GetErrors()[0].GetCode(), apiError.GetErrors()[0].GetType(), apiError.GetErrors()[0].GetDetails())
 	}
 	if httpRes != nil {
-		return httpRes.Status
+		return fmt.Errorf("http status %d", httpRes.Status)
 	}
 
-	return fmt.Sprintf("%v", err)
+	return err
 }


### PR DESCRIPTION
Frieza should abort snapshots on API errors.

Otherwise, it might think that there are no resources of a kind, and delete everything when cleaning.
